### PR TITLE
build: run postman tests on push and pull_request

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -36,9 +36,8 @@ jobs:
   run-e2e-tests:
     uses: netcracker/qubership-apihub-ci/.github/workflows/run-e2e-tests.yml@main
     needs: build-docker-image
-    if: github.event_name == 'pull_request'
-    with:
-      postman-collections-run: false
+    if: (github.event_name == 'push') || (github.event_name == 'pull_request')
+    with:      
       apihub-build-task-consumer-image-tag: ${{ needs.build-docker-image.outputs.image_tag }}      
       # apihub-backend-image-tag: dev
       # apihub-ui-image-tag: dev


### PR DESCRIPTION
- run postman tests, since changes in api-processor could break backend tests
- run e2e tests on push, since changes to build-task-consumer are not often and usually just dependency changes directly in develop