### PR TITLE
feat: start builds with relaxed api-processor version validation if migration is in progress

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^7.0.0",
-        "@netcracker/qubership-apihub-api-processor": "5.3.0",
+        "@netcracker/qubership-apihub-api-processor": "feature-migration-mode",
         "@sinclair/typebox": "^0.32.1",
         "adm-zip": "^0.5.10",
         "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.0.0",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "feature-migration-mode",
     "@sinclair/typebox": "^0.32.1",
     "adm-zip": "^0.5.10",
     "dotenv": "^16.3.1",

--- a/src/modules/builder/builder.service.ts
+++ b/src/modules/builder/builder.service.ts
@@ -315,11 +315,15 @@ export class BuilderService implements OnModuleInit {
     const withoutChangelog = noChangeLog && buildType === 'build'
     withoutChangelog && this.logger.log('[Builder Service] Run build without changelog')
 
+    const { migrationInProgress } = await this.registry.getSystemInfo()
+    const apiProcessorVersionValidationLevel = migrationInProgress ? 'major' as const : 'strict' as const
+    migrationInProgress && this.logger.log('[Builder Service] Migration in progress, using major version validation')
+
     //override native logger
     console.debug = (message: string) => {
       this.logger.debug(message)
     }
-    const result = await builder.run({ withoutChangelog })
+    const result = await builder.run({ withoutChangelog, apiProcessorVersionValidationLevel })
     this.logger.log(`[Builder Service] Built ${result.operations.size ?? 0} operations from ${config.packageId}/${config.version}`)
 
     return await builder.createNodeVersionPackage()

--- a/src/modules/builder/builder.service.ts
+++ b/src/modules/builder/builder.service.ts
@@ -21,6 +21,7 @@ import {
   ResolvedGroupDocuments,
   ResolvedVersionDocuments,
   ResolvedPackage,
+  VERSION_VALIDATION_LEVEL,
 } from '@netcracker/qubership-apihub-api-processor'
 import { ConfigService } from '@nestjs/config'
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
@@ -316,7 +317,7 @@ export class BuilderService implements OnModuleInit {
     withoutChangelog && this.logger.log('[Builder Service] Run build without changelog')
 
     const { migrationInProgress } = await this.registry.getSystemInfo()
-    const apiProcessorVersionValidationLevel = migrationInProgress ? 'major' : 'strict'
+    const apiProcessorVersionValidationLevel = migrationInProgress ? VERSION_VALIDATION_LEVEL.MAJOR : VERSION_VALIDATION_LEVEL.STRICT
     migrationInProgress && this.logger.log('[Builder Service] Migration in progress, using major version validation')
 
     //override native logger

--- a/src/modules/builder/builder.service.ts
+++ b/src/modules/builder/builder.service.ts
@@ -316,7 +316,7 @@ export class BuilderService implements OnModuleInit {
     withoutChangelog && this.logger.log('[Builder Service] Run build without changelog')
 
     const { migrationInProgress } = await this.registry.getSystemInfo()
-    const apiProcessorVersionValidationLevel = migrationInProgress ? 'major' as const : 'strict' as const
+    const apiProcessorVersionValidationLevel = migrationInProgress ? 'major' : 'strict'
     migrationInProgress && this.logger.log('[Builder Service] Migration in progress, using major version validation')
 
     //override native logger

--- a/src/modules/registry/registry.service.ts
+++ b/src/modules/registry/registry.service.ts
@@ -358,6 +358,23 @@ export class RegistryService implements OnModuleInit {
     )
   }
 
+  public async getSystemInfo(): Promise<{ migrationInProgress: boolean }> {
+    const url = `${this.baseUrl}/api/v1/system/info`
+    const logTag = '[getSystemInfo]'
+
+    return lastValueFrom(this.httpService
+      .get(url, { headers: this.headers })
+      .pipe(
+        retry({ delay: this.requestRetryHandler(logTag) }),
+        map(({ data }) => ({ migrationInProgress: data.migrationInProgress ?? false })),
+        catchError(err => {
+          this.logger.error(logTag, err?.response?.data ?? err)
+          return of({ migrationInProgress: false })
+        }),
+      ),
+    )
+  }
+
   private requestRetryHandler(logMessage: string): (error: any, retryCount: number) => ObservableInput<any> {
     return (error, retryCount) => {
       if (retryCount > RETRY_COUNT || NO_RETRY_STATUSES.includes(error?.response?.status)) {


### PR DESCRIPTION
 ### Summary

  When the platform is undergoing a full migration, previously published versions may have been built with an older `api-processor`. The strict builder version check blocks changelog builds for these versions, even though the mismatch is expected and temporary.
  
  This PR makes `build-task-consumer` migration-aware: before each build, it queries the backend for migration status and, if a migration is in progress, switches version validation from `strict` to `major` (only the major semver component is compared).

  ### Changes

  **`src/modules/registry/registry.service.ts`**
  - Added `getSystemInfo()` method that calls `GET /api/v1/system/info`
  - Uses the existing retry pipeline (`requestRetryHandler`) for transient failures
  - Falls back to `{ migrationInProgress: false }` on error, so builds are never blocked by a failed system-info request

  **`src/modules/builder/builder.service.ts`**
  - Calls `getSystemInfo()` before `builder.run()`
  - Passes `apiProcessorVersionValidationLevel: 'major' | 'strict'` to the builder based on `migrationInProgress` flag
  - Logs when migration mode is active for observability

  ### Related PRs

  - **qubership-apihub-api-processor**: adds `apiProcessorVersionValidationLevel` option, `major`-mode validation logic, and `previousVersionBuilderVersion` / `currentVersionBuilderVersion` metadata
  - **qubership-apihub-backend** (`update_builder_version_check`): backend migration stage `RebuildRelaxedBuilds` that rebuilds versions with relaxed-build metadata after migration completes

  ### How it works

  1. `builder.service` calls `registry.getSystemInfo()` → `GET /api/v1/system/info`
  2. If `migrationInProgress` is `true`, validation level is set to `major`
  3. `api-processor` compares only the major part of builder versions during changelog builds
  4. Mismatched builder versions are recorded in `info.json` metadata
  5. After migration, the backend `RebuildRelaxedBuilds` stage re-processes these versions with the current `api-processor`
