### PR TITLE
chore: normalize public contacts and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please, follow these guidelines to make the contribution process easy and effect
 
 ## Contributor License Agreement
 
-You must sign the [Contributor License Agreement](https://pages.netcracker.com/cla-main.html) in order to contribute.
+You must sign the [Contributor License Agreement](https://github.com/Netcracker/qubership-workflow-hub/blob/main/CLA/cla.md) in order to contribute.
 
 ## Code of Conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
-# Security Reporting Process
+# Security Policy
+
+## Reporting a Vulnerability
 
 Please, report any security issue to `opensourcegroup@netcracker.com` where the issue will be triaged appropriately.
 
 If you know of a publicly disclosed security vulnerability please IMMEDIATELY email `opensourcegroup@netcracker.com`
 to inform the team about the vulnerability, so we may start the patch, release, and communication process.
 
-# Security Release Process
+## Security Release Process
 
 If the vulnerability is found in the latest stable release, then it would be fixed in patch version for that release.
 E.g., issue is found in 2.5.0 release, then 2.5.1 version with a fix will be released.


### PR DESCRIPTION
## Summary

- Normalize public contact files and example email addresses.
- Keep API support and repository feedback contacts aligned with approved addresses.
- Replace personal-looking examples with neutral example data where applicable.

## Changed files

- CONTRIBUTING.md
- SECURITY.md

## Commit

7d6c86c chore: normalize public contacts and examples
 CONTRIBUTING.md | 2 +-
 SECURITY.md     | 6 ++++--
 2 files changed, 5 insertions(+), 3 deletions(-)
