### PR TITLE
fix: remove deprecated search scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@netcracker/qubership-apihub-api-processor": "feature-remove-deprecated-search-scopes",
+    "@netcracker/qubership-apihub-api-processor": "dev",
     "@sinclair/typebox": "^0.32.1",
     "adm-zip": "^0.5.10",
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "feature-remove-deprecated-search-scopes",
     "@sinclair/typebox": "^0.32.1",
     "adm-zip": "^0.5.10",
     "dotenv": "^16.3.1",

--- a/src/modules/builder/builder.schema.ts
+++ b/src/modules/builder/builder.schema.ts
@@ -39,7 +39,6 @@ export const OperationSchema = Type.Object({
     method: Type.Any({enum: ['get', 'post', 'put', 'delete', 'patch', 'head', 'options', 'connect', 'trace'], description: 'HTTP Method'}),
   }),
   data: Type.Any(),
-  searchScopes: Type.Optional(Type.Any()),
   changes: Type.Optional(Type.Array(Type.Any())),
   changeSummary: Type.Optional(Type.Any()),
   refPackage: Type.Optional(Type.Object({


### PR DESCRIPTION
## Summary
Drops the deprecated `searchScopes` field from the operation validation schema
and pulls the matching api-processor version. Aligns the build task consumer with
the removal of v3 search scopes.

## What changed
- Remove `searchScopes: Type.Optional(Type.Any())` from `OperationSchema`
  (`src/modules/builder/builder.schema.ts`). The field was optional, so this is a
  backward-compatible schema change.
- Bump `@netcracker/qubership-apihub-api-processor` to the version that no longer
  emits `searchScopes`.

## Why
The api-processor no longer produces `searchScopes`, and the backend no longer
consumes it; keeping it in the schema is dead validation surface.
