### PR TITLE
fix: remove obsolete `release-candidate` version status

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "feature-version-statuses-update",
     "@sinclair/typebox": "^0.32.1",
     "adm-zip": "^0.5.10",
     "dotenv": "^16.3.1",

--- a/src/modules/builder/builder.schema.ts
+++ b/src/modules/builder/builder.schema.ts
@@ -63,7 +63,7 @@ export const PublishFilesConfigSchema = Type.Object({
   }),
   packageId: Type.String(),
   version: Type.String(),
-  status: Type.Any({enum: ['release', 'draft', 'archived', 'release-candidate'], description: 'Version status'}),
+  status: Type.Any({enum: ['release', 'draft', 'archived'], description: 'Version status'}),
   publishId: Type.String(),
   versionFolder: Type.Optional(Type.String()),
   previousVersion: Type.Optional(Type.String()),


### PR DESCRIPTION
## Why

api-processor drops `release-candidate` from `VERSION_STATUS`, and build-task-consumer is a thin wrapper over
it. The publish schema here still advertises the status in its `status` enum, so the two would disagree about
what a caller may send.

## What

- `src/modules/builder/builder.schema.ts`: the `status` enum of `PublishFilesConfigSchema` is now
  `['release', 'draft', 'archived']`.