### PR TITLE
feat: support reading APIHUB API key from a file

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -16,15 +16,24 @@
 
 import { ConfigFactory } from '@nestjs/config/dist/interfaces'
 import { config } from 'dotenv'
+import { existsSync, readFileSync } from 'node:fs'
+import * as process from 'node:process'
 
 import { Configuration } from './configuration.interface'
-import * as process from 'node:process'
 
 config()
 
+function readApiKey(): string {
+  const apiKeyFile = process.env.APIHUB_API_KEY_FILE
+  if (apiKeyFile && existsSync(apiKeyFile)) {
+    return readFileSync(apiKeyFile, 'utf8').trim()
+  }
+  return process.env.APIHUB_API_KEY ?? ''
+}
+
 const configuration: Configuration = {
   apihubUrl: process.env.APIHUB_BACKEND_ADDRESS ?? '',
-  apiKey: process.env.APIHUB_API_KEY ?? '',
+  apiKey: readApiKey(),
   statusInterval: Number(process.env.JOB_STATUS_INTERVAL ?? '5000'),
   requestInterval: Number(process.env.JOB_REQUEST_INTERVAL ?? '3000'),
   operationsBatch: Number(process.env.OPERATIONS_BUILD_BATCH ?? '16'),


### PR DESCRIPTION
## Summary
- Read the APIHUB API key from `APIHUB_API_KEY_FILE` when the path exists
- Keep `APIHUB_API_KEY` as a fallback for local/docker-compose setups

## Test plan
- [ ] Deploy with Helm that mounts the secret and sets `APIHUB_API_KEY_FILE`; confirm consumer authenticates to the backend
- [ ] Run locally/docker-compose with only `APIHUB_API_KEY`; confirm fallback still works
- [ ] Confirm empty/missing file path does not crash startup when fallback env is set

Made with [Cursor](https://cursor.com)