### PR TITLE
feat: [FE] Remove Package Version Archived status

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "@nestjs/config": "^3.0.0",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
-        "@netcracker/qubership-apihub-api-processor": "5.6.0",
+        "@netcracker/qubership-apihub-api-processor": "bugfix-remove-package-version-archived-status",
         "@sinclair/typebox": "^0.32.1",
         "adm-zip": "^0.5.10",
         "dotenv": "^16.3.1",
@@ -29,7 +29,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
-        "@netcracker/qubership-apihub-api-unifier": "2.9.1",
+        "@netcracker/qubership-apihub-api-unifier": "dev",
         "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
         "@types/adm-zip": "^0.5.1",
         "@types/express": "^4.17.21",
@@ -1894,11 +1894,11 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-api-diff": {
-      "version": "3.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-diff/3.4.1/466c3a949682b2c7d245ca53080e18c522d401b9",
-      "integrity": "sha512-e7jhKBqE+jhIHfnsqVC00WWM4UIRdncU/piNK1sJ70QLZa54gz2uMvMmuE3HUcIzyDKXwH8JrIXE5yf/+RTreg==",
+      "version": "3.4.2-dev.20260731103313",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-diff/3.4.2-dev.20260731103313/8979484a880771a50bf3b5c3ea825ac0e7abcd3a",
+      "integrity": "sha512-x8CPtNccERvJCG0Xo4+E2Kl7+20hSao++QNEYEhXEHTWg10/GwN2IzVtJ2gEcOEtmHUQbMaK8g4R72cUPa5ezw==",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-unifier": "2.9.1",
+        "@netcracker/qubership-apihub-api-unifier": "dev",
         "@netcracker/qubership-apihub-ddlapi": "1.0.0",
         "@netcracker/qubership-apihub-json-crawl": "1.2.2",
         "fast-equals": "6.0.0"
@@ -1914,16 +1914,16 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-api-processor": {
-      "version": "5.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-processor/5.6.0/37d80aa5193c45d8bd841dfad8507d785a411920",
-      "integrity": "sha512-kzvUbKW5sjT9b6IY40KonzShpaKu/84U+LvHODiTQyvzhbvAimH/j1/fNtYliknptgjG3Nrma3Ilnq0Llvq6tg==",
+      "version": "5.6.1-bugfix-remove-package-version-archived-status.20260824073523",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-processor/5.6.1-bugfix-remove-package-version-archived-status.20260824073523/970a559c6a7738ac3b67166e160fe6b35cc3357c",
+      "integrity": "sha512-6w2V4UiD4qf6/60bd9JM6zGGcqqFcwCVBr2Cwabt8i9mNBBjZCQX8Dv9+Xznq5GcEx6HzpiBf+kbUY4BS+tvtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/parser": "^3.6.0",
-        "@netcracker/qubership-apihub-api-diff": "3.4.1",
-        "@netcracker/qubership-apihub-api-unifier": "2.9.1",
+        "@netcracker/qubership-apihub-api-diff": "dev",
+        "@netcracker/qubership-apihub-api-unifier": "dev",
         "@netcracker/qubership-apihub-ddlapi": "1.0.0",
-        "@netcracker/qubership-apihub-graphapi": "1.0.12",
+        "@netcracker/qubership-apihub-graphapi": "dev",
         "@netcracker/qubership-apihub-json-crawl": "1.2.2",
         "adm-zip": "0.5.10",
         "ajv": "^8.12.0",
@@ -1970,12 +1970,12 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-api-unifier": {
-      "version": "2.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/2.9.1/4d29352ab0fa99e15fdc44f5d545ab03846347a5",
-      "integrity": "sha512-LQIUfyp0wCKYSSX11s3PcEdJT6UjMW3Vaps7bGCa4h5QgSi93IZLZhHdFer0j/9p6sTLkguN+IgktHAEYVREtg==",
+      "version": "2.9.2-dev.20260731102626",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-api-unifier/2.9.2-dev.20260731102626/bd8036a273e53d45c6c1c241f1d2ff038f285630",
+      "integrity": "sha512-OyGLpQnVrQyjge4JeASn5VgstHeNhh4jP3zmuJ9Z/d8NYpN5cwX1f0lVHTUsQ6IQrQLQMLKFcONAHNiCMmltww==",
       "dependencies": {
         "@netcracker/qubership-apihub-ddlapi": "1.0.0",
-        "@netcracker/qubership-apihub-graphapi": "1.0.12",
+        "@netcracker/qubership-apihub-graphapi": "dev",
         "@netcracker/qubership-apihub-json-crawl": "1.2.2",
         "fast-equals": "4.0.3",
         "flatted": "^3.2.9",
@@ -2000,9 +2000,9 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-graphapi": {
-      "version": "1.0.12",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.12/7a5de3858dd78484ffc12d50cffeb3d8751bfc93",
-      "integrity": "sha512-HrqgnUHGG1QakF2z5WGsCMNnJXC+GiXh1vWoehtlEl25GqCAbydoMJBnbUnC+liiv8eUKqCSszolMNiHdeu/qA==",
+      "version": "1.0.13-dev.20260731102444",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-graphapi/1.0.13-dev.20260731102444/7bd64d9251c0c207d2f950632125d265e01fe262",
+      "integrity": "sha512-9xMEEoquGNyW1VWwaU6XeGgdGBy1MALlT7zc/LAL+AjDsQ7SzIFNaD0JjhZ+VjfxO/uH/tazbGy08yCp8qwKrw==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
-    "@netcracker/qubership-apihub-api-processor": "dev",
+    "@netcracker/qubership-apihub-api-processor": "bugfix-remove-package-version-archived-status",
     "@sinclair/typebox": "^0.32.1",
     "adm-zip": "^0.5.10",
     "dotenv": "^16.3.1",

--- a/src/modules/builder/builder.schema.ts
+++ b/src/modules/builder/builder.schema.ts
@@ -63,7 +63,7 @@ export const PublishFilesConfigSchema = Type.Object({
   }),
   packageId: Type.String(),
   version: Type.String(),
-  status: Type.Any({enum: ['release', 'draft', 'archived'], description: 'Version status'}),
+  status: Type.Any({enum: ['release', 'draft'], description: 'Version status'}),
   publishId: Type.String(),
   versionFolder: Type.Optional(Type.String()),
   previousVersion: Type.Optional(Type.String()),


### PR DESCRIPTION
# PR — qubership-apihub-build-task-consumer

`feat: [FE] Remove Package Version Archived status`

Part of the coordinated removal of the `archived` package version status
(Netcracker/qubership-apihub#762).

## Changes

- `src/modules/builder/builder.schema.ts` — `'archived'` removed from the build config
  status enum, leaving `['release', 'draft']`
- `package.json` / `npm-shrinkwrap.json` — api-processor pinned to the feature branch build

